### PR TITLE
Add GitHub CI

### DIFF
--- a/.github/workflows/build-release-daily.yml
+++ b/.github/workflows/build-release-daily.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: configure system
+      run: bin/system-setup
+    - name: build release
+      run: sudo bin/build-release daily

--- a/bin/build-release
+++ b/bin/build-release
@@ -85,6 +85,10 @@ build_arch() {
     else
         time "${cmd[@]}" 2>&1 | tee "$log"
     fi
+    # at this point we do not need buildroot tree anymore and GitHub CI has just 14GB space
+    if [ ! -z $GITHUB_WORKSPACE ]; then
+        rm -rf "$OUT/build/$arch/buildroot" "$OUT/build/$arch/ccache" "$OUT/build/$arch/skeleton"
+    fi
     ret=$?
     logevent "finish $arch [ret=$ret]"
     return $ret


### PR DESCRIPTION
To make sure that changes do not break things we need a way to check them. So let's use CI provided by GitHub.

As we have 14GB of storage we remove buildroot (~3GB) after each architecture got built. It did what we needed so no need to keep it - rootfs.tar is all we want in next steps.