### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+dist: bionic
+
+install: 
+  - bin/system-setup
+
+jobs:
+  fast_finish: true # fail once any job fail
+
+env:
+  - ARCHES=aarch64
+  - ARCHES=arm
+  - ARCHES=i386
+  - ARCHES=x86_64
+  - ARCHES=powerpc
+  - ARCHES=ppc64
+  - ARCHES=ppc64le
+
+script:
+  - sudo QUIET=1 bin/build-release daily
+

--- a/bin/build-release
+++ b/bin/build-release
@@ -35,6 +35,12 @@ GVER="${GVER:-2.02~beta2-36ubuntu3.22}" # Ubuntu 16.04
 ME=$(readlink -f "$0")
 MY_D=${ME%/*}
 PATH=${MY_D}:$PATH
+QUIET=${QUIET:-}
+
+MAKE_QUIET=
+if [ ! -z $QUIET ]; then
+    MAKE_QUIET="-s"
+fi
 
 set -e
 set -o pipefail
@@ -75,7 +81,7 @@ build_arch() {
     fi
     arch="$1"
     log="${OUT}/build-$arch.log"
-    cmd=( make ARCH=$arch "OUT_D=$OUT/build/$arch"
+    cmd=( make $MAKE_QUIET ARCH=$arch "OUT_D=$OUT/build/$arch"
           ${CCACHE_D:+"BR2_CCACHE_DIR=${CCACHE_D}/$arch"} )
 
     logevent "start $arch" -
@@ -139,7 +145,7 @@ logevent "end download"
 logevent "start unpack" -
 rm -Rf "buildroot-${BR_VER}"
 rm -f buildroot
-tar -xvf download/buildroot-${BR_VER}.tar.gz
+tar -xf download/buildroot-${BR_VER}.tar.gz
 ln -snf buildroot-${BR_VER} buildroot
 
 # we do not do this here, so that we're not dependent on the
@@ -153,7 +159,7 @@ echo "$VER" > "src/etc/cirros/version"
 logevent "end unpack"
 
 logevent "start br-source" -
-make ARCH=${ARCHES%% *} br-source
+make $MAKE_QUIET ARCH=${ARCHES%% *} br-source
 logevent "end br-source"
 
 logevent "start kernel and grub downloads" -

--- a/bin/common-functions.sh
+++ b/bin/common-functions.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 DEBUG=0
+QUIET=${QUIET:-}
 
 error() { echo "$@" 1>&2; }
 
@@ -18,7 +19,11 @@ dl() {
     [ -f "$target" ] && return
     t=$(dirname "$target")
     tfile=$(mktemp "$t/.${0##*/}.XXXXXX") || return
-    wget "$url" -O "$tfile" &&
+    wget_quiet=
+    if [ ! -z $QUIET ]; then
+        wget_quiet="-q"
+    fi
+    wget $wget_quiet "$url" -O "$tfile" &&
         mv "$tfile" "$target" ||
         { t=$?; rm -f "$tfile"; return $t; }
 }

--- a/bin/system-setup
+++ b/bin/system-setup
@@ -20,7 +20,7 @@ DEPS=(
     mtools
     parallel
     python
-    qemu-kvm
+    qemu-utils
     quilt
     rsync
     texinfo


### PR DESCRIPTION
Travis CI is free for FOSS projects.

We do parallel builds - one per architecture. 

Some in-progress changes to get build quieter due to 4MB log length limit.