### PR TITLE
grab-grub-ieee: use grub-mkimage or grub2-mkimage in PATH.

### DIFF
--- a/bin/grab-grub-ieee
+++ b/bin/grab-grub-ieee
@@ -16,6 +16,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+GRUB_MKIMAGE=${GRUB_MKIMAGE:-}
 
 source "${0%/*}/common-functions.sh"
 
@@ -43,6 +44,15 @@ deb2tar() {
 
     local deb="$1" tar="$2"
 
+    if [ -z "$GRUB_MKIMAGE" ]; then
+        # grub-mkimage is grub2-mkimage on fedora/centos.
+        for n in grub-mkimage grub2-mkimage; do
+            command -v $n >/dev/null 2>&1 && GRUB_MKIMAGE=$n && break
+        done
+        [ -n "$GRUB_MKIMAGE" ] ||
+            fail "No grub-mkimage found. cannnot build efi for $efiarch/$format"
+    fi
+
     t=$(dirname "$deb")
     tdir=$(mktemp -d "$t/.XXXXXX") || return
 
@@ -57,7 +67,7 @@ deb2tar() {
           test linux"
 
     debug 2 "grub-mkimage: creating grub powerpc-ieee1275 image"
-    grub-mkimage --directory "${tdir}/deb/usr/lib/grub/powerpc-ieee1275" \
+    $GRUB_MKIMAGE --directory "${tdir}/deb/usr/lib/grub/powerpc-ieee1275" \
         --prefix "(ieee1275/disk,gpt1)/boot/grub" \
         --output "$tdir/${gbin}" \
         --format "powerpc-ieee1275" \


### PR DESCRIPTION
Handle grub-mkimage being named grub2-mkimage as it is in Fedora.
