### PR TITLE
test-boot: simple script to do boot test of just built image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,13 @@ language: bash # same as minimal
 install: 
   - bin/system-setup
 
+addons:
+  apt:
+    packages:
+      - cloud-utils
+      - qemu-system
+      - openbios-ppc
+
 jobs:
   fast_finish: true # fail once any job fail
 
@@ -18,5 +25,5 @@ env:
   - ARCHES=ppc64le
 
 script:
-  - sudo QUIET=1 bin/build-release daily
-
+  # we want to test does image boots after build
+  - sudo BOOTTEST=true QUIET=1 bin/build-release daily

--- a/bin/build-release
+++ b/bin/build-release
@@ -36,6 +36,12 @@ ME=$(readlink -f "$0")
 MY_D=${ME%/*}
 PATH=${MY_D}:$PATH
 QUIET=${QUIET:-}
+BOOTTEST=${BOOTTEST:-false}
+
+case "$BOOTTEST" in
+    true|false) :;;
+    *) echo "Unknown value for BOOTTEST: ${BOOTTEST}"; exit 1;;
+esac
 
 MAKE_QUIET=
 if [ ! -z $QUIET ]; then
@@ -280,5 +286,13 @@ logevent "finish populate release" -
 msg "output in $OUT/release"
 msg "entire process took $SECONDS seconds"
 logevent "finished" "$tstart"
+
+if [ "true" = "${BOOTTEST}" ]; then
+    for arch in ${ARCHES}; do
+        IMG=$OUT/release/cirros-$VER-$arch-disk.img \
+        RELEASE_DIR=$OUT/release \
+        test-boot
+    done
+fi
 
 # vi: tabstop=4 expandtab

--- a/bin/test-boot
+++ b/bin/test-boot
@@ -1,0 +1,41 @@
+#!/bin/sh
+MEM=${MEM:-512}
+GUESTARCH="${GUESTARCH:-$(echo $(basename $IMG)| cut -d'-' -f3)}"
+VER=$(echo $(basename $IMG)| cut -d'-' -f2)
+
+echo '{"instance-id": "9068aef2-213e-4e43-830f-accdbadde897"}' > meta-data
+{ echo '#!/bin/sh'; echo 'echo Hello from inside'; echo 'poweroff -f'; } > user-data
+
+
+cloud-localds -d qcow2 seed.img user-data meta-data
+
+qemu-img create -f qcow2 -b "$IMG" -F qcow2 disk1.img >/dev/null 2>&1
+
+EXTRA_OPTS=
+
+case $GUESTARCH in
+    arm)
+        MACHINE=virt
+        EXTRA_OPTS="-kernel $RELEASE_DIR/cirros-$VER-arm-kernel -initrd $RELEASE_DIR/cirros-$VER-arm-initramfs" ;;
+    aarch64)
+        MACHINE=virt
+        EXTRA_OPTS="-cpu cortex-a57 -kernel $RELEASE_DIR/cirros-$VER-aarch64-kernel -initrd $RELEASE_DIR/cirros-$VER-aarch64-initramfs" ;;
+    ppc64|ppc64le)
+        MACHINE=pseries
+        GUESTARCH=ppc64 ;;
+    powerpc)
+        # No idea how to run it
+        exit ;;
+    i386|x86_64)
+        MACHINE=pc ;;
+esac
+
+set -x  # show next command
+
+qemu-system-$GUESTARCH -m $MEM -machine $MACHINE \
+   -device virtio-net-pci,netdev=net00 \
+   -netdev type=user,id=net00,net=10.0.12.0/24,host=10.0.12.2 \
+   -drive if=virtio,file=disk1.img \
+   -drive if=virtio,file=seed.img \
+   $EXTRA_OPTS \
+   -nographic

--- a/bin/test-boot
+++ b/bin/test-boot
@@ -21,7 +21,7 @@ case $GUESTARCH in
         MACHINE=virt
         EXTRA_OPTS="-cpu cortex-a57 -kernel $RELEASE_DIR/cirros-$VER-aarch64-kernel -initrd $RELEASE_DIR/cirros-$VER-aarch64-initramfs" ;;
     ppc64|ppc64le)
-        MACHINE=pseries
+        MACHINE=pseries-2.12
         GUESTARCH=ppc64 ;;
     powerpc)
         # No idea how to run it


### PR DESCRIPTION
Arguments:
- IMG - path to disk.img for test
- RELEASE_DIR - path to 'release' dir (needed only for aarch64/arm)

VM gets booted with qemu and will power off via cloud-init user-data
script.

PowerPC testing is disabled - needs qemu configuration

Partially closes #9