### PR TITLE
CI: we do not need Ruby so let go with minimal shell env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 dist: bionic
 
+language: bash # same as minimal
+
 install: 
   - bin/system-setup
 


### PR DESCRIPTION
Default Travis CI environment contains Ruby. We do not need it so let's go with minimal to get more disk space.