### PR TITLE
set default disk image size to 100MB for all archs

### DIFF
--- a/bin/build-release
+++ b/bin/build-release
@@ -114,7 +114,6 @@ get_grub_format() {
 get_img_size() {
     local arch=$1
     case "$arch" in
-        powerpc|ppc*|aarch64) size=96M;;
         *) size="";;
     esac
     echo $size

--- a/bin/bundle
+++ b/bin/bundle
@@ -21,7 +21,7 @@ source "${0%/*}/common-functions.sh"
 
 TEMP_D=""
 UMOUNT=""
-DEF_SIZE=${DEF_SIZE:-32M}
+DEF_SIZE=${DEF_SIZE:-100M}
 DEF_MODULES="acpiphp e1000 ne2k-pci 8139cp pcnet32 ip_tables"
 
 Usage() {


### PR DESCRIPTION
x86_64 fails all the time due to lack of disk space