### PR TITLE
load-modules: be a bit more quiet

### DIFF
--- a/src/etc/init.d/load-modules
+++ b/src/etc/init.d/load-modules
@@ -8,7 +8,38 @@ loadmods() {
 		line="${line%%#*}"
 		[ -n "$line" ] || continue
 		if [ ! -d /sys/module/$line ]; then
-				modprobe $line
+                        case "$line" in
+                            # in Ubuntu vfat uses cp437 and iso8859-1
+                            vfat|nls_cp437|nls_iso8859-1)
+                                grep vfat /proc/filesystems >/dev/null
+                                if [ 1 -eq $? ]; then
+                                    modprobe $line
+                                fi
+                                ;;
+                            isofs)
+                                grep iso9660 /proc/filesystems >/dev/null
+                                if [ 1 -eq $? ]; then
+                                    modprobe $line
+                                fi
+                                ;;
+                            # sr_mod depends on sg and cdrom
+                            cdrom|sr_mod|sg)
+                                if [ ! -d /sys/module/sr_mod ]; then
+                                    modprobe $line
+                                fi
+                                ;;
+                            qemu_fw_cfg)  # present in Linux 4.6+
+                                minimum_kernel=4.6
+                                current_kernel=$(uname -r)
+                                min=$(echo -e $minimum_kernel"\n"$current_kernel | sort -n | head -n1)
+                                if [ $min = $minimum_kernel ]; then
+                                    modprobe $line
+                                fi
+                                ;;
+                            *)
+                                modprobe $line
+                                ;;
+                        esac
 		fi
 	done
 }

--- a/src/etc/init.d/load-modules
+++ b/src/etc/init.d/load-modules
@@ -7,7 +7,9 @@ loadmods() {
 	while read line; do
 		line="${line%%#*}"
 		[ -n "$line" ] || continue
-		modprobe $line
+		if [ ! -d /sys/module/$line ]; then
+				modprobe $line
+		fi
 	done
 }
 

--- a/src/init
+++ b/src/init
@@ -6,10 +6,11 @@ ROOTFS_LABEL="cirros-rootfs"
 
 . /lib/cirros/shlib
 
-mkdir -p /proc /newroot /dev /tmp
+mkdir -p /proc /newroot /dev /tmp /sys
 
 mount -t devtmpfs /dev /dev
 mount -t proc /proc /proc
+mount -t sysfs /sys /sys
 
 echo "6 4 1 7" >/proc/sys/kernel/printk
 
@@ -62,12 +63,12 @@ if [ -z "$ROOT" ]; then
 		set +f
 		for x in /*; do
 			case "$x" in
-				/dev|/proc|/newroot) : ;;
+				/dev|/proc|/newroot|/sys) : ;;
 				*) items="$items $x";;
 			esac
 		done
 		set -f
-		mkdir -p "${NEWROOT_MP}/dev" "${NEWROOT_MP}/proc"
+		mkdir -p "${NEWROOT_MP}/dev" "${NEWROOT_MP}/proc" "${NEWROOT_MP}/sys"
 		cp -a $items "${NEWROOT_MP}/"
 		cp -a "/dev/console" "$NEWROOT_MP/dev/"
 		mount -o remount,ro "$NEWROOT_MP"


### PR DESCRIPTION
Image contains a list of kernel modules to load. Several of them are
built-in into kernel so 'modprobe' fails and complains that kernel
module is not found.

As we control which features land in an image we know that functionality
we want is present - either as kernel module or built-in into kernel.

So let modprobe be quiet.

Closes: #23