### PR TITLE
Allow to use 'test-boot' for more than just CI

### DIFF
--- a/bin/build-release
+++ b/bin/build-release
@@ -291,7 +291,7 @@ if [ "true" = "${BOOTTEST}" ]; then
     for arch in ${ARCHES}; do
         img="$OUT/release/cirros-$VER-$arch-disk.img"
         logevent "start test-boot $arch ${img##*/}" -
-        IMG="$img" RELEASE_DIR=$OUT/release test-boot
+        POWEROFF=true IMG="$img" RELEASE_DIR=$OUT/release test-boot
         logevent "end test-boot $arch ${img##*/}"
     done
 fi

--- a/bin/test-boot
+++ b/bin/test-boot
@@ -19,10 +19,15 @@
 MEM=${MEM:-512}
 GUESTARCH="${GUESTARCH:-$(echo $(basename $IMG)| cut -d'-' -f3)}"
 VER=$(echo $(basename $IMG)| cut -d'-' -f2)
+POWEROFF=${POWEROFF:-false}
 
 echo '{"instance-id": "9068aef2-213e-4e43-830f-accdbadde897"}' > meta-data
-{ echo '#!/bin/sh'; echo 'echo Hello from inside'; echo 'poweroff -f'; } > user-data
 
+if [ "true" == $POWEROFF ]; then
+    { echo '#!/bin/sh'; echo 'echo Hello from inside'; echo 'poweroff -f'; } > user-data
+else
+    echo "" > user-data
+fi
 
 cloud-localds -d qcow2 seed.img user-data meta-data
 


### PR DESCRIPTION
new variable POWEROFF (defaults to 'false') controls a way test image is booted

build-release will boot image in same way as it is now - boot and power off.

test-boot can be used to boot resulting image and play with it.