### PR TITLE
load-modules: some code style changes.

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -78,6 +78,8 @@ out_d_in=${4}
 
 PATH="$topdir/bin:$PATH"
 src_dir="${topdir}/src"
+export CIRROS_LIB="${src_dir}/lib/cirros/shlib_cirros"
+export CIRROS_SHLIB="${src_dir}/lib/cirros/shlib"
 src_symlinks="${topdir}/symlinks.list"
 makedevs_list="${topdir}/makedevs.list"
 fixup_fs="${topdir}/fixup-fs"
@@ -180,9 +182,18 @@ depmod -a --basedir "${kernel_d}" "${kver}" ||
     fail "failed to run depmod"
 
 mdep="${kernel_d}/lib/modules/${kver}/modules.dep"
+mbuiltin="${kernel_d}/lib/modules/${kver}/modules.builtin"
 for x in ${MODULES}; do
-    grep -q "/${x}.ko" "${mdep}" ||
-        { error "WARNING: no ${x} in kernel package!"; continue; }
+    loose_name=${x//-/.}
+    if ! grep -q "/${loose_name}.ko:" "${mdep}"; then
+        if [ -f "$mbuiltin" ] &&
+            builtin_line=$(grep "/${loose_name}.ko$" "$mbuiltin" ); then
+            debug 1 "module $x is builtin to $kver"
+        else
+            error "WARNING: no ${x} module in $kver kernel package!"
+        fi
+        continue;
+    fi
     awk -F: '$1 ~ mat {
         sub(":","",$1)
         printf("%s/%s\n",p,$1)
@@ -192,14 +203,21 @@ for x in ${MODULES}; do
             printf("%s/%s\n", p, deps[x]);
             x++
         }
-    }' mat="/${x}.ko$" p="lib/modules/${kver}" "${mdep}"
+    }' mat="/${loose_name}.ko$" p="lib/modules/${kver}" "${mdep}"
 done > "${kern_modules}"
 sort -u "${kern_modules}" > "${kern_files}"
+if [ -f "$mbuiltin" ]; then
+    echo ${mbuiltin#${kernel_d}/} >> "${kern_files}"
+fi
 vmlinuz=$( cd "${kernel_d}" && [ -f boot/vmlinu?-* ] &&
     echo boot/vmlinu?-* ) && echo "${vmlinuz}" >> "${kern_files}" &&
     ln -sf "$vmlinuz" "$kernel_d/vmlinuz" && echo "vmlinuz" >> "$kern_files" ||
     fail "no kernel (boot/vmlinuz-*) found in ${kpkg_in}"
 echo "boot/config-$kver" >> "$kern_files"
+
+mfound=$(sed -e 's,.*/,,' -e 's,[.]ko$,,' "${kern_modules}" | sort)
+mfound=$(echo $mfound)
+debug 1 "including these modules: $mfound"
 
 tar -C "${kernel_d}" -cpf - \
     --files-from "${kern_files}" > "${kernel_tar}" ||

--- a/src/etc/init.d/load-modules
+++ b/src/etc/init.d/load-modules
@@ -1,47 +1,73 @@
 #!/bin/sh
 # vi: ts=4 noexpandtab
 # load modules
+. ${CIRROS_LIB:=/lib/cirros/shlib_cirros} ||
+	{ echo "failed to read ${CIRROS_LIB}" 1>&2; exit 1; }
+
+get_fslist() {
+	# set _RET to a list of currently supported filesystems
+	# stdin should be /proc/filesystems (proc(5))
+	local line="" fs="" tab='	'
+	_RET=""
+	while read line; do
+		line=${line#nodev}
+		line=${line#$tab}
+		_RET="${_RET} $line"
+	done
+}
 
 loadmods() {
-	local line
-	while read line; do
-		line="${line%%#*}"
-		[ -n "$line" ] || continue
-		if [ ! -d /sys/module/$line ]; then
-                        case "$line" in
-                            # in Ubuntu vfat uses cp437 and iso8859-1
-                            vfat|nls_cp437|nls_iso8859-1)
-                                grep vfat /proc/filesystems >/dev/null
-                                if [ 1 -eq $? ]; then
-                                    modprobe $line
-                                fi
-                                ;;
-                            isofs)
-                                grep iso9660 /proc/filesystems >/dev/null
-                                if [ 1 -eq $? ]; then
-                                    modprobe $line
-                                fi
-                                ;;
-                            # sr_mod depends on sg and cdrom
-                            cdrom|sr_mod|sg)
-                                if [ ! -d /sys/module/sr_mod ]; then
-                                    modprobe $line
-                                fi
-                                ;;
-                            qemu_fw_cfg)  # present in Linux 4.6+
-                                minimum_kernel=4.6
-                                current_kernel=$(uname -r)
-                                min=$(echo -e $minimum_kernel"\n"$current_kernel | sort -n | head -n1)
-                                if [ $min = $minimum_kernel ]; then
-                                    modprobe $line
-                                fi
-                                ;;
-                            *)
-                                modprobe $line
-                                ;;
-                        esac
+	local mod="" mod_ubar="" fslist="" kver="" fails="" skip=""
+	get_fslist </proc/filesystems || error "Failed to read filesystems."
+	fslist=" $_RET "
+	kver=$(uname -r)
+	local builtins="" mbuiltin="/lib/modules/${kver}/modules.builtin"
+	if [ -f "$mbuiltin" ]; then
+		builtins=$(sed -e 's,.*/,,' -e 's/[.]ko$//' -e 's/-/_/g' "$mbuiltin")
+		builtins=" $(echo $builtins) "
+	fi
+	while read mod; do
+		[ -n "$mod" ] || continue
+		skip=""
+		replace "$mod" "-" "_"
+		mod_ubar="$_RET"
+		[ -d "/sys/module/${mod_ubar}" ] && skip="already loaded."
+		if [ -z "$skip" ]; then
+			case "${builtins}" in
+				*\ ${mod_ubar}\ *) skip="builtin."
+			esac
 		fi
+		if [ -z "$skip" ]; then
+			case "$mod_ubar" in
+				isofs)
+					case "$fslist" in
+						*\ iso9660\ *) skip="iso9660 fs already supported.";;
+					esac
+					;;
+				# in Ubuntu vfat uses cp437 and iso8859-1
+				vfat)
+					case "$fslist" in
+						*\ vfat\ *) skip="vfat fs already supported.";;
+					esac
+					;;
+				# present in Linux 4.6+
+				qemu_fw_cfg)
+					kver_cmp "$kver" -lt 4.6 && skip="kernel $kver older than 4.6"
+					;;
+			esac
+		fi
+		if [ -n "$skip" ]; then
+			debug 2 "not loading '$mod': $skip"
+			continue
+		fi
+		modprobe $mod || fails="$fails $mod"
 	done
+
+	if [ -n "$fails" ]; then
+		error "failed loading these modules: $fails"
+		return 1
+	fi
+	return 0
 }
 
 parse_modules() {
@@ -55,6 +81,7 @@ parse_modules() {
 		arm*) march=",arm,$arch,";;
 	esac
 	while read line; do
+		[ -n "$line" ] || continue
 		modinfo=${line%%#*}
 		[ "$modinfo" = "$line" ] && comment="" ||
 			comment="${line#${modinfo}#}"
@@ -83,8 +110,13 @@ case "$1" in
 		if [ -f "$MODULES_FILE" ]; then
 			[ -d "/lib/modules/$(uname -r)" ] || exit 0
 			march=$(uname -m)
-			parse_modules "$MODULES_FILE" "$march" | loadmods
-			[ "$march" = "ppc64" ] && sleep 1
+			parse_out=$(parse_modules "$MODULES_FILE" "$march") ||
+				fail "Failed to parse modules"
+			echo "${parse_out}" | loadmods ||
+				fail "failed to load modules."
+			if [ "$march" = "ppc64" ]; then
+				sleep 1
+			fi
 		fi
 		;;
 	stop|restart|reload) : ;;

--- a/src/lib/cirros/shlib
+++ b/src/lib/cirros/shlib
@@ -453,4 +453,34 @@ path_has() {
 		[ "${p#*${del}${tok}/${del}}" != "$p" ]
 }
 
+replace() {
+	# replace(src,from,to,max=-1)
+	# replace char 'from' in 'src' with 'to'.
+	# For a few replacements, this is much faster than
+	# using sed or tr as it does not invoke any subprocesses.
+	local src="$1" from="$2" to="$3" max="${4:--1}"
+	# if no replaces were to be done return src
+	[ $max -eq 0 ] && { _RET="$src"; return 0; }
+
+	local pre="" post="" rem="" ret="" count=0
+	rem="$src"
+	while [ -n "$rem" ] && [ $max -lt 0 -o $count -lt $max ]; do
+		if [ "$count" = "$max" ]; then
+			ret="$ret$rem"
+			break
+		fi
+		post=${rem#*${from}}
+		if [ "$post" = "$rem" ]; then
+			ret="$ret$rem"
+			rem=""
+		else
+			pre=${rem%${from}${post}}
+			ret="$ret$pre$to"
+			rem="$post"
+		fi
+		count=$(($count+1))
+	done
+	_RET="$ret$rem"
+}
+
 # vi: ts=4 noexpandtab syntax=sh

--- a/src/lib/cirros/shlib_cirros
+++ b/src/lib/cirros/shlib_cirros
@@ -99,6 +99,29 @@ cirros_version_available() {
 	return
 }
 
+kver_to_num() {
+	# turn a kernel version (X.Y.Z or X.Y.Z-*) into a integer
+	local kver="$1" maj="" min="" mic="0"
+	kver=${kver%%-*}
+	maj=${kver%%.*}
+	min=${kver#${maj}.}
+	min=${min%%.*}
+	mic=${kver#${maj}.${min}.}
+	[ "$kver" = "$mic" ] && mic=0
+	_RET=$(($maj*1000*1000+$min*1000+$mic))
+}
+
+kver_cmp() {
+	# kver_cmp(a, operator, b)
+	# operator is one "-ge", "-gt", "-lt", "-le", "="
+	local op="$2" n1="" n2=""
+	kver_to_num "$1"
+	n1="$_RET"
+	kver_to_num "$3"
+	n2="$_RET"
+	[ $n1 $op $n2 ]
+}
+
 . ${CIRROS_SHLIB:=/lib/cirros/shlib} ||
 	{ error "failed to read ${CIRROS_SHLIB}" 1>&2; exit 1; }
 


### PR DESCRIPTION
I hope this is somewhat more readable, and should also run
faster by "caching" the list of supported loaded filesystems.

Other changes:
 * get rid of the 4 space indentation... for better or (probably) worse
   these scripts are currently tab indentation.
 * use 'debug' and provide a reason if we skip load.
 * compare the kernel version using added kver_cmp.