### PR TITLE
Document intended use and login info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-This is a project to build a small cloud image that has useful tools and function for debugging or developing cloud infrastructure. Supported architectures are:
+The CirrOS project provides linux disk and kernel/initramfs images.
+The images are well suited for testing as they are small and boot
+quickly.  Please note that:
+
+ * **Images are provided for test only**.  They should not be used in production.
+ * **Images have well known login information**.  Users can log in with 'cirros:letsgocubs' locally or remotely and have passwordless sudo access to root.
+
+CirrOS images have useful tools and function for debugging or developing cloud infrastructure. Supported architectures are:
 
  * aarch64 (64-bit Armv8 often called arm64)
  * arm (32-bit Armv7)


### PR DESCRIPTION
Document that cirros images should only be used for test and that
they have well known login information.

Fixes #10.