### PR TITLE
test-boot: pass '-vga none' when booting.

### DIFF
--- a/bin/test-boot
+++ b/bin/test-boot
@@ -61,4 +61,5 @@ qemu-system-$GUESTARCH -m $MEM -machine $MACHINE \
    -drive if=virtio,file=disk1.img \
    -drive if=virtio,file=seed.img \
    $EXTRA_OPTS \
-   -nographic
+   -nographic \
+   -vga none


### PR DESCRIPTION
ppc64 systems need to have -vga none passed to ensure that
the output gets sent to the serial device.

We'll just pass that on all arch in our test.

See https://bugs.launchpad.net/bugs/1563887 for more info.