### PR TITLE
modules: qemu_sys_fw is only available on aarch64 and x86.

### DIFF
--- a/src/etc/modules
+++ b/src/etc/modules
@@ -6,7 +6,7 @@ pcnet32            # arch=x86
 
 ## VirtIO
 9pnet_virtio
-qemu_fw_cfg
+qemu_fw_cfg        # arch=x86,aarch64
 virtio_blk
 virtio_input
 virtio_net


### PR DESCRIPTION
Just update src/etc/modules so we do not get failures of load-modules
due to lack of module on those arch.