### PR TITLE
load-modules: Fix bug in parse_modules and print loaded modules.

### DIFF
--- a/src/etc/init.d/load-modules
+++ b/src/etc/init.d/load-modules
@@ -67,6 +67,9 @@ loadmods() {
 		error "failed loading these modules: $fails"
 		return 1
 	fi
+	local loaded=""
+	loaded=$(awk '{print $1}' /proc/modules | sort | tr '\n' ' ')
+	debug 0 "currently loaded modules: $loaded"
 	return 0
 }
 
@@ -79,10 +82,12 @@ parse_modules() {
 		amd64|x86_64) march=",x86_64,x86,";;
 		ppc64|powerpc) march=",powerpc,ppc64,";;
 		arm*) march=",arm,$arch,";;
+		*) march=",$arch,";;
 	esac
 	while read line; do
 		[ -n "$line" ] || continue
 		modinfo=${line%%#*}
+		[ -n "$modinfo" ] || continue
 		[ "$modinfo" = "$line" ] && comment="" ||
 			comment="${line#${modinfo}#}"
 		[ "${comment#*arch=}" = "$comment" ] &&


### PR DESCRIPTION
Fix a bug in parse_modules for arches not in the case statement.
This was aarch64 and ppc64le.

Also, when load-modules runs on startup, it is useful to print the
loaded modules.