### PR TITLE
test-boot: shutdown from rc.local rather than directly from user-data.

### DIFF
--- a/bin/test-boot
+++ b/bin/test-boot
@@ -23,10 +23,20 @@ POWEROFF=${POWEROFF:-false}
 
 echo '{"instance-id": "9068aef2-213e-4e43-830f-accdbadde897"}' > meta-data
 
-if [ "true" == $POWEROFF ]; then
-    { echo '#!/bin/sh'; echo 'echo Hello from inside'; echo 'poweroff -f'; } > user-data
-else
+if [ "$POWEROFF" != "true" ]; then
     echo "" > user-data
+else
+    cat >user-data <<"EOF"
+#!/bin/sh
+rclocal="/etc/rc.local"
+cat >>$rclocal <<"END_RC_LOCAL"
+#!/bin/sh
+read up idle </proc/uptime
+echo "[$up] Hello and goodbye from inside $0"
+poweroff
+END_RC_LOCAL
+chmod 755 $rclocal
+EOF
 fi
 
 cloud-localds -d qcow2 seed.img user-data meta-data


### PR DESCRIPTION
The change here is to have user-data append to rc.local rather than
calling 'poweroff -f' itself.  This
 a.) allows us to not need '-f' to poweroff.
 b.) means the console all of the S* scripts in rc3.d/
     will get executed before shutdown.
     /etc/init.d/rc.sysinit executes rc.local as the very
     last thing it does.

Closes #39.