### PR TITLE
Fixes to make dropbear working again

### DIFF
--- a/src/etc/init.d/S50dropbear
+++ b/src/etc/init.d/S50dropbear
@@ -13,18 +13,21 @@ start() {
 
 	echo -n "Starting dropbear sshd: "
 	umask 077
-	# Ensure host keys are changed when instance ID changes
-	cirros-per instance remove-dropbear-host-keys -- rm -rf /etc/dropbear
-	
-	# Make sure dropbear directory exists
-	if [ ! -d /etc/dropbear ]; then
-		mkdir -p /etc/dropbear
+	local dropbear_key_dir="/etc/dropbear"
+
+	# Handle symlinked directories
+	if [ -L "$dropbear_key_dir" ]; then
+		dropbear_key_dir=$(readlink -f "$dropbear_key_dir")
 	fi
+
+	# Ensure host keys are changed when instance ID changes
+	cirros-per instance remove-dropbear-host-keys -- rm -rf "$dropbear_key_dir"
+	mkdir -p "$dropbear_key_dir"
 
 	# Regenerate invalid or missing keys
 	local ktype file
 	for ktype in rsa ecdsa; do
-		file="/etc/dropbear/dropbear_${ktype}_host_key"
+		file="${dropbear_key_dir}/dropbear_${ktype}_host_key"
 		# -f = input file, -y = validate and print pubkey info
 		if ! dropbearkey -f "$file" -y &>/dev/null; then
 			if [ -e "$file" ]; then


### PR DESCRIPTION
Init file for dropbear is a bit outdated in regards to upstream - this PR adds support for key dirs that are symlinks and drops the attempt to generate a dss key, which is no longer supported.