### PR TITLE
dropbear: Do not try to generate dss keys

### DIFF
--- a/src/etc/init.d/S50dropbear
+++ b/src/etc/init.d/S50dropbear
@@ -23,7 +23,7 @@ start() {
 
 	# Regenerate invalid or missing keys
 	local ktype file
-	for ktype in rsa dss ecdsa; do
+	for ktype in rsa ecdsa; do
 		file="/etc/dropbear/dropbear_${ktype}_host_key"
 		# -f = input file, -y = validate and print pubkey info
 		if ! dropbearkey -f "$file" -y &>/dev/null; then
@@ -31,7 +31,7 @@ start() {
 				echo "Removing invalid key: $file"
 				rm -f "$file"
 			fi
-			# -t = type (dss, rsa, ecdsa), -f = output file
+			# -t = type (rsa, ecdsa), -f = output file
 			dropbearkey -t "$ktype" -f "$file" >/dev/null 2>&1 ||
 		echo "WARN: generating key of type $ktype failed!"
 		fi


### PR DESCRIPTION
Dropbear has dropped support for dss keys for security
reasons [1], so it's no longer possible to generate them.

[1] https://bugs.archlinux.org/task/60523

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>