### PR TITLE
Backport Busybox fix to 'ip' command- closes #54

### DIFF
--- a/patches-buildroot/busybox-fix-ip-o-patch.patch
+++ b/patches-buildroot/busybox-fix-ip-o-patch.patch
@@ -1,0 +1,46 @@
+---
+ package/busybox/busybox-ip-fix-ip-o-link.patch |   39 +++++++++++++++++++++++++
+ 1 file changed, 39 insertions(+)
+
+--- /dev/null
++++ buildroot-2019.02.1/package/busybox/busybox-ip-fix-ip-o-link.patch
+@@ -0,0 +1,39 @@
++From bb3a9531b28f5c946452b92c8ac5a0951c5eab03 Mon Sep 17 00:00:00 2001
++From: =?UTF-8?q?Stefan=20S=C3=B8rensen?= <stefan.sorensen@spectralink.com>
++Date: Sat, 30 Mar 2019 18:24:46 +0100
++Subject: ip: Fix ip -o link
++MIME-Version: 1.0
++Content-Type: text/plain; charset=UTF-8
++Content-Transfer-Encoding: 8bit
++
++Commit db169f253854db572c0c2b7e3d74ebbe6afdb97f breaks the "ip -o link"
++command, no output is displayed.. Fix by only excluding the link info if
++in oneline mode and if the address family is not AF_PACKET.
++
++function                                             old     new   delta
++ipaddr_list_or_flush                                1232    1202     -30
++
++Signed-off-by: Stefan Sørensen <stefan.sorensen@spectralink.com>
++Signed-off-by: Denys Vlasenko <vda.linux@googlemail.com>
++---
++ networking/libiproute/ipaddress.c | 4 ++--
++ 1 file changed, 2 insertions(+), 2 deletions(-)
++
++diff --git a/networking/libiproute/ipaddress.c b/networking/libiproute/ipaddress.c
++index d088caf4c..0a1b5d798 100644
++--- a/networking/libiproute/ipaddress.c
+++++ b/networking/libiproute/ipaddress.c
++@@ -574,8 +574,8 @@ int FAST_FUNC ipaddr_list_or_flush(char **argv, int flush)
++ 	}
++
++ 	for (l = linfo; l; l = l->next) {
++-		if (no_link
++-		 || (oneline || print_linkinfo(&l->h) == 0)
+++		if ((oneline && G_filter.family != AF_PACKET)
+++		 || (print_linkinfo(&l->h) == 0)
++ 		/* ^^^^^^^^^ "ip -oneline a" does not print link info */
++ 		) {
++ 			struct ifinfomsg *ifi = NLMSG_DATA(&l->h);
++--
++cgit v1.2.1
++

--- a/patches-buildroot/series
+++ b/patches-buildroot/series
@@ -1,1 +1,2 @@
 ifupdown-cirros.patch
+busybox-fix-ip-o-patch.patch


### PR DESCRIPTION
OpenStack Tempest tests fail due to change to 'ip -o link' output.

https://git.busybox.net/busybox/commit/?id=bb3a9531b28f5c946452b92c8ac5a0951c5eab03