### PR TITLE
Add ahci module - closes #64

### DIFF
--- a/src/etc/modules
+++ b/src/etc/modules
@@ -49,3 +49,4 @@ ip_tables
 cdrom
 sr_mod
 sg
+ahci


### PR DESCRIPTION
Without this module it isn't possible to see any attached SATA devices
once booted, even when booting from SATA based disks.

As discussed in the associated issue the OpenStack Nova project is
looking to test the `q35` machine type that requires the use of SATA
based cdrom config drives. Including and loading this module allows
these config drives to be seen correctly within launched instances.