### PR TITLE
Building on Ubuntu 20.04 LTS / cloud-init parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Resulting images can be booted using QEMU. Several ways of booting are provided:
 
 # Build instructions
 
-The following works on Ubuntu 18.04 LTS, running on x86_64. Native building for other architectures is not recommended. Support for building under other distributions is limited and not tested.
+The following works on Ubuntu 18.04 LTS and 20.04 LTS, running on x86_64. Native building for other architectures is not recommended. Support for building under other distributions is limited and not tested.
 
 ## Clone sources
 

--- a/bin/system-setup
+++ b/bin/system-setup
@@ -9,12 +9,14 @@ DEPS=(
     bc
     bison
     build-essential
+    cpio
     grub-common
     git
     dosfstools
     flex
     gdisk
     gettext
+    kmod
     kpartx
     libncurses5-dev
     mtools
@@ -23,6 +25,7 @@ DEPS=(
     qemu-utils
     quilt
     rsync
+    sudo
     texinfo
     unzip
     wget

--- a/src/lib/cirros/ds/configdrive
+++ b/src/lib/cirros/ds/configdrive
@@ -12,7 +12,7 @@ SEED_POST_D="/var/lib/cloud/seed/configdrive"
 
 Usage() {
 	cat <<EOF
-Usage: ${0##*/} mode output_d
+Usage: ${0##*/} mode output_dir
 
    Datasource for openstack config drive
 EOF
@@ -168,7 +168,7 @@ while [ $# -ne 0 ]; do
 	shift;
 done
 
-[ $# -eq 2 ] || bad_Usage "must provide mode and output dir"
+[ $# -eq 2 ] || bad_Usage "must provide mode and output_dir"
 mode="$1"
 out_d="$2"
 

--- a/src/lib/cirros/ds/ec2
+++ b/src/lib/cirros/ds/ec2
@@ -14,7 +14,7 @@ fail() { [ $# -eq 0 ] || error "$@"; exit 1; }
 
 Usage() {
 	cat <<EOF
-Usage: ${0##*/} mode output_d
+Usage: ${0##*/} mode output_dir
 
    Datasource for EC2 metadata service
    Requires network.
@@ -110,7 +110,7 @@ while [ $# -ne 0 ]; do
 	shift;
 done
 
-[ $# -eq 2 ] || bad_Usage "must provide mode and data dir"
+[ $# -eq 2 ] || bad_Usage "must provide mode and output_dir"
 mode="$1"
 out_d="$2"
 

--- a/src/lib/cirros/ds/nocloud
+++ b/src/lib/cirros/ds/nocloud
@@ -12,7 +12,7 @@ LABEL="cidata"
 
 Usage() {
 	cat <<EOF
-Usage: ${0##*/} mode output_d
+Usage: ${0##*/} mode output_dir
 
    Datasource for 'nocloud' config disk.
 EOF
@@ -130,7 +130,7 @@ while [ $# -ne 0 ]; do
 	shift;
 done
 
-[ $# -eq 2 ] || bad_Usage "must provide mode and output dir"
+[ $# -eq 2 ] || bad_Usage "must provide mode and output_dir"
 mode="$1"
 out_d="$2"
 


### PR DESCRIPTION
This includes a couple of updates to build on Ubuntu 20.04 LTS, and cloud-init scripts parameters standardization.