### PR TITLE
Add no_timer_check to kernel command line - closes #69

### DIFF
--- a/src/boot/grub/menu.lst
+++ b/src/boot/grub/menu.lst
@@ -7,6 +7,6 @@ title     Linux Kernel
 # it is changed on disk image creation.
 root      (hd0)
 # FS_LABEL
-kernel    /vmlinuz LABEL=cirros-rootfs ro console=tty1 console=ttyS0
+kernel    /vmlinuz LABEL=cirros-rootfs ro console=tty1 console=ttyS0 no_timer_check
 initrd    /initrd.img
 EOF


### PR DESCRIPTION
This avoids known issues when running Cirros directly under QEMU (TCG)
where APIC setup failures cause a kernel panic early in the boot
process.