### PR TITLE
Add sctp module

### DIFF
--- a/src/etc/modules
+++ b/src/etc/modules
@@ -40,6 +40,7 @@ ip_tables
 #sit
 #veth
 #vxlan
+sctp
 
 ## Block storage
 ## Present for config_drive support


### PR DESCRIPTION
SCTP protocol support in cirros is required for testing the OpenStack
Octavia project.