### PR TITLE
gitignore: add build related entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+build*
 buildroot*
+ccache
 download
 grubd
 output
+src/etc/cirros/version

--- a/src/etc/cirros/version
+++ b/src/etc/cirros/version
@@ -1,1 +1,0 @@
-unreleased


### PR DESCRIPTION
There is no need to track ccache, build or cirros version in git.

Change-Id: Iccd668f5103ef64b3a1a3cf2d0cced73dc8530ed