### PR TITLE
add module for PCI Express Intel network card

### DIFF
--- a/src/etc/modules
+++ b/src/etc/modules
@@ -1,5 +1,6 @@
 # modules here are loaded one per line
 e1000
+e1000e
 ne2k-pci           # arch=x86
 8139cp             # arch=x86
 pcnet32            # arch=x86


### PR DESCRIPTION
On x86_64/q35 or aarch64 (or other PCI Express based platform) we can
get PCIe version of Intel card.

e1000  is for PCI card
e1000e is for PCI Express card

Probably closes #60