### PR TITLE
CI: Switch workflow trigger from master to main

### DIFF
--- a/.github/workflows/build-cirros.yaml
+++ b/.github/workflows/build-cirros.yaml
@@ -3,10 +3,10 @@ name: CirrOS image builder
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   cirros-build-matrix:


### PR DESCRIPTION
Need to change workflow trigger to `main` since the root branch was changed from `master`.