### PR TITLE
Add 8021q module

### DIFF
--- a/src/etc/modules
+++ b/src/etc/modules
@@ -30,7 +30,7 @@ nls_iso8859-1
 nls_utf8
 
 ## Networking
-#8021q
+8021q
 #gre
 #ipip
 ip_tables


### PR DESCRIPTION
Allows to create vlan interfaces.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>