### PR TITLE
Add route when router is not in subnet range

### DIFF
--- a/src/sbin/cirros-dhcpc
+++ b/src/sbin/cirros-dhcpc
@@ -121,6 +121,14 @@ renew_bound() {
 
 		for i in $router; do
 			debug 1 "route add default gw $i dev $interface"
+			# Add a route to this IP
+			# This is usually not necessary if the IP is in the same
+			# subnet as the interface.
+			# But this may not always be the case (e.g. an interface
+			# with /32 IP such as what is given to instances on
+			# ovhcloud)
+			route add $i dev $interface
+			# Adding this IP as default gw
 			route add default gw $i dev $interface
 		done
 	fi


### PR DESCRIPTION
When the DHCP server give some routers out of interface subnet range, the route was not properly set.
Adding a route before setting the default gateway fixed the issue