### PR TITLE
Add injection for /etc/os-release

### DIFF
--- a/bin/build-release
+++ b/bin/build-release
@@ -169,7 +169,14 @@ ln -snf buildroot-${BR_VER} buildroot
 
 ( cd buildroot && QUILT_PATCHES="$PWD/../patches-buildroot" quilt push -a )
 
-echo "$VER" > "src/etc/cirros/version"
+cat << EOF > "src/etc/os-release"
+PRETTY_NAME="CirrOS $VER"
+NAME="CirrOS"
+VERSION_ID="$VER"
+ID=cirros
+HOME_URL="https://cirros-cloud.net"
+BUG_REPORT_URL="https://github.com/cirros-dev/cirros/issues"
+EOF
 logevent "end unpack"
 
 logevent "start br-source" -
@@ -247,7 +254,6 @@ if ! $daily; then
         cd "cirros-$VER" && git checkout "$tagname" &&
         cd .. &&
         rm -Rf "cirros-$VER/.git/" &&
-        echo "$VER" > "cirros-$VER/src/etc/cirros/version" &&
         tar cvzf - cirros-$VER ) > "$OUT/release/cirros-$VER-source.tar.gz"
 fi
 

--- a/src/lib/cirros/shlib_cirros
+++ b/src/lib/cirros/shlib_cirros
@@ -65,9 +65,21 @@ ds_cat_item() {
 }
 
 cirros_version() {
-	[ -r /etc/cirros/version ] ||
-		{ _RET="unreleased"; return 0; }
-	{ read _RET < /etc/cirros/version; } >/dev/null 2>&1
+	local orelf="${1:-/etc/os-release}" v="" quote="\""
+	_RET="unreleased"
+	[ -r "$orelf" ] || return 0;
+	while read line ; do
+		case "$line" in
+			VERSION_ID=*)
+				v=${line#*=}
+				v=${v%${quote}}
+				v=${v#${quote}}
+				_RET="$v"
+				return 0
+				;;
+		esac
+	done < "$orelf"
+	return
 }
 
 cirros_version_available() {


### PR DESCRIPTION
Same as #85, but without the borked rebase :sweat_smile:. Learned my lesson.

Adds an injection for `/etc/os-release` and updates the `cirros_version()` function.

Closes #79 