### PR TITLE
Build on tag and pass tag name to build-release for tag build.

### DIFF
--- a/.github/workflows/build-cirros.yaml
+++ b/.github/workflows/build-cirros.yaml
@@ -4,10 +4,11 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "[01].[0-9]+.[0-9]+"
   pull_request:
     branches:
       - main
-
 jobs:
   cirros-build-matrix:
     strategy:
@@ -48,7 +49,10 @@ jobs:
         run: echo "127.0.0.1 invisible-mirror.net" | sudo tee -a /etc/hosts
 
       - name: Build CirrOS image
-        run: bin/build-release daily
+        env:
+          # use tag name for tag build, or 'daily' for anything else.
+          reason: "${{ github.ref_type == 'tag' && github.ref_name || 'daily' }}"
+        run: bin/build-release "$reason"
 
       - name: Boot CirrOS image
         run: bin/test-boot


### PR DESCRIPTION
The goal is to build on tags and publish releases with tags. This will call bin/build-release with 'daily' for a non-tag build and the tag name for a tag build.