### PR TITLE
Bump kernel to 5.15.0-48.54, the latest version in jammy-updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ This will do a full buildroot build, which will take a while. The output that Ci
  * Download a kernel to use. The kernel input to bundle must be in deb format. The ubuntu '-virtual'  kernel is used as a starting point. Version can be taken from https://launchpad.net/ubuntu/+source/linux page.
 
 ```bash
-   $ kver="5.15.0-33.34"
+   $ kver="5.15.0-48.54"
    $ ./bin/grab-kernels "$kver" $ARCH
 ```      
 

--- a/bin/build-release
+++ b/bin/build-release
@@ -30,7 +30,7 @@ shift
 pre=cirros-$VER
 BR_VER="${BR_VER:-2022.02.4}" # WARNING: this may be non-trivial to change
 ARCHES="${ARCHES:-x86_64 arm aarch64 ppc64le}"
-KVER="${KVER:-5.15.0-33.34}" # Ubuntu 22.04
+KVER="${KVER:-5.15.0-48.54}" # Ubuntu 22.04
 GVER="${GVER:-2.06-2ubuntu7}" # Ubuntu 22.04
 ME=$(readlink -f "$0")
 MY_D=${ME%/*}


### PR DESCRIPTION
Just update the kernel version prior to 0.6.0 release.