### PR TITLE
Set filecap for traceroute

### DIFF
--- a/conf/buildroot-aarch64.config
+++ b/conf/buildroot-aarch64.config
@@ -2871,7 +2871,7 @@ BR2_PACKAGE_LIBBSD_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_LIBBYTESIZE is not set
 # BR2_PACKAGE_LIBCAP is not set
-# BR2_PACKAGE_LIBCAP_NG is not set
+BR2_PACKAGE_LIBCAP_NG=y
 
 #
 # libcgroup needs a glibc toolchain w/ C++

--- a/conf/buildroot-arm.config
+++ b/conf/buildroot-arm.config
@@ -2970,7 +2970,7 @@ BR2_PACKAGE_LIBBSD_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_LIBBYTESIZE is not set
 # BR2_PACKAGE_LIBCAP is not set
-# BR2_PACKAGE_LIBCAP_NG is not set
+BR2_PACKAGE_LIBCAP_NG=y
 
 #
 # libcgroup needs a glibc toolchain w/ C++

--- a/conf/buildroot-ppc64le.config
+++ b/conf/buildroot-ppc64le.config
@@ -2413,7 +2413,7 @@ BR2_PACKAGE_LIBBSD_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBBSD is not set
 # BR2_PACKAGE_LIBBYTESIZE is not set
 # BR2_PACKAGE_LIBCAP is not set
-# BR2_PACKAGE_LIBCAP_NG is not set
+BR2_PACKAGE_LIBCAP_NG=y
 
 #
 # libcgroup needs a glibc toolchain w/ C++

--- a/conf/buildroot-x86_64.config
+++ b/conf/buildroot-x86_64.config
@@ -2897,7 +2897,7 @@ BR2_PACKAGE_LIBBSD_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_LIBBYTESIZE is not set
 # BR2_PACKAGE_LIBCAP is not set
-# BR2_PACKAGE_LIBCAP_NG is not set
+BR2_PACKAGE_LIBCAP_NG=y
 
 #
 # libcgroup needs a glibc toolchain w/ C++

--- a/src/etc/init.d/rc.sysinit
+++ b/src/etc/init.d/rc.sysinit
@@ -55,6 +55,8 @@ mkdir /run/var.tmp
 
 hostname -F /etc/hostname
 
+filecap /usr/bin/traceroute NET_RAW
+
 f="/bin/lxc-is-container" && write_lxc_is_container > "$f" && chmod 755 "$f"
 
 if ! is_lxc; then


### PR DESCRIPTION
The traceroute command needs the NET_RAW capability in order to be able to run with icmp (-I option) for non-root users. Since capabilities are not preserved during our build process nor when copying from the ramdisk to the root-fs, we explicitly set the capability during boot.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>