### PR TITLE
Feature: add the 'none' datasource and document kernel command line.

### DIFF
--- a/doc/kernel-cmdline.md
+++ b/doc/kernel-cmdline.md
@@ -1,0 +1,23 @@
+# Cirros Kernel Command line
+
+Cirros supports customization from the kernel command line.
+Kernel command line values override defaults in the image or initramfs.
+
+## Parameters
+
+ * `root=` - string, default="LABEL=cirros-rootfs"
+
+    The default behavior is to search for a filesystem with a label 'cirros-rootfs' and use it for the root filesystem. Other supported values:
+
+     * `root=LABEL=<name>` - search for filesystem with a label '<name>'
+     * `root=UUID=<uuid>` - search for filesystem with a uuid '<uuid>'
+     * `root=ramdisk` | `root=none` - run entirely out of the initramfs.
+
+ * `init=<PROGRAM>` - string, default=/sbin/init. PROGRAM will be executed as init.
+
+ * `dslist=ds1[,ds2[,ds3...]]` - string, default="".  Search through the listed datasources.  If value is empty (default) then read `/etc/cirros-init/config` for the list.
+
+   Useful value is `dslist=none` which will use the 'none' datasource.
+
+ * `debug-initramfs` - boolean, default=false.  Drop into a shell to debug initramfs early in the initramfs.
+ * `verbose` or `verbose=INT`.  increase verbosity / debut output of init.

--- a/src/init
+++ b/src/init
@@ -16,6 +16,8 @@ echo "6 4 1 7" >/proc/sys/kernel/printk
 
 parse_cmdline
 
+VERBOSITY=${KC_VERBOSE}
+
 for x in $KC_CONSOLES; do
 	[ "$x" = "$KC_CONSOLE" ] ||
 		echo "further output written to $KC_CONSOLE" > "$x";
@@ -49,7 +51,7 @@ else
 	debug 1 "did not find a device matching $rootspec"
 fi
 
-if [ "$KC_DEBUG" = "1" ]; then
+if [ "${KC_DEBUG_INITRAMFS}" = "1" ]; then
 	echo "dropping into initramfs debug shell"
 	/bin/sh
 fi

--- a/src/lib/cirros/ds/none
+++ b/src/lib/cirros/ds/none
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+VERBOSITY=1
+CONFIG="/etc/cirros-init/ds-none"
+NAME="${0##*/}"
+
+. ${CIRROS_SHLIB:=/lib/cirros/shlib} ||
+	{ echo "failed to read ${CIRROS_SHLIB}" 1>&2; exit 1; }
+
+Usage() {
+	cat <<EOF
+Usage: ${0##*/} mode output_d
+
+   The 'none' datasource.
+
+   This is always "found" and does nothing.
+EOF
+}
+
+search_local() {
+	local out_d="$1"
+	local data_d="${out_d}/data"
+	echo "i-dsnone" > "${data_d}/instance-id"
+	echo 0 > "$out_d/result"
+}
+
+apply() {
+	return 0
+}
+
+short_opts="hv"
+long_opts="help,verbose"
+getopt_out=$(getopt --name "${0##*/}" \
+	--options "${short_opts}" --long "${long_opts}" -- "$@") &&
+	eval set -- "${getopt_out}" ||
+	bad_Usage
+
+while [ $# -ne 0 ]; do
+	cur=${1}; next=${2};
+	case "$cur" in
+		-h|--help) Usage ; exit 0;;
+		-v|--verbose) VERBOSITY=$((${VERBOSITY}+1));;
+		--) shift; break;;
+	esac
+	shift;
+done
+
+[ $# -eq 2 ] || bad_Usage "must provide mode and output dir"
+mode="$1"
+out_d="$2"
+
+[ "$mode" = "local" -o "$mode" = "apply-local" ] ||
+	{ debug 2 "only supported in mode 'local'"; exit 0; }
+
+[ ! -e "$CONFIG" ] || . "$CONFIG" ||
+	fail "failed to read $CONFIG"
+
+if [ "$mode" = "local" ]; then
+	search_local "$out_d"
+elif [ "$mode" = "apply-local" ]; then
+	apply "$mode" "$out_d"
+else
+	fail "error, unexpected input"
+fi
+
+exit
+# vi: ts=4 noexpandtab

--- a/src/sbin/cirros-ds
+++ b/src/sbin/cirros-ds
@@ -62,11 +62,11 @@ cirros_ds() {
 		{ read cmdline < /proc/cmdline; } >/dev/null 2>&1
 		for tok in $cmdline; do
 			case "$tok" in
-				dslist=) cmdline_list=none;;
+				dslist=) cmdline_list=empty;;
 				dslist=*) cmdline_list=${tok#dslist=};;
 			esac
 		done
-		if [ -n "${cmdline_list}" -a "${cmdline_list}" != "none" ]; then
+		if [ -n "${cmdline_list}" -a "${cmdline_list}" != "empty" ]; then
 			IFS=","; set -- ${cmdline_list}; IFS="$oifs"
 			debug 2 "found datasource list on cmdline:" "$@"
 		else


### PR DESCRIPTION
  * Add kernel command line documentation.

  * Add the 'none' datasource.
    
    The 'none' datasource will just be found no matter what.
    It allows easily / intentionally using without a datasource.
    
    A change in behavior of cirros-ds was needed as it previously
    took 'dslist=none' as a alias for 'dslist='.  Explicitly setting
    dslist= is inteneded to read the value from /etc/cirros-ds/config.

  * init: set verbosity to cmdline verbose= and fix debug-initramfs
    
    debug-initramfs on the kernel command line should have dropped
    into a shell, but it would not due to variable name use.
    
    Also, change the kernel cmdline 'verbose=' or 'verbose' to affect
    the value of VERBOSITY to make 'debug' or 'info' output appear
