### PR TITLE
Fix stopping of dhcpcd service. (#107)

### DIFF
--- a/patches-buildroot/README
+++ b/patches-buildroot/README
@@ -1,6 +1,5 @@
 This directory contains patches to be applied to buildroot.
-They're in quilt style format, but nothing automated will apply
-them.  After downloading and extracting buildroot, linking it
-to ./buildroot , you will need to run:
-  ( cd buildroot && QUILT_PATCHES=$PWD/../patches-buildroot quilt push -a )
+They're in quilt(1) style format.
 
+bin/bundle' will apply the patches to buildroot source if
+there is a patches-buildroot/series file.

--- a/patches-buildroot/package-dhcpcd-fix-pid-path.patch
+++ b/patches-buildroot/package-dhcpcd-fix-pid-path.patch
@@ -1,0 +1,47 @@
+From f73718ce5efe2cfda8bd3c8fc7cc72e30b2b10f1 Mon Sep 17 00:00:00 2001
+From: Konstantin Menyaev <KAMenyaev@sberdevices.ru>
+Date: Mon, 5 Sep 2022 04:09:13 +0300
+Subject: [PATCH] package/dhcpcd: fix pid path
+
+From the README:
+    dhcpcd-9 defaults the run directory to `/var/run/dhcpcd` instead of
+    `/var/run` and the prefix of dhcpcd has been removed from the files.
+
+Make it so.
+
+Signed-off-by: Konstantin Menyaev <KAMenyaev@sberdevices.ru>
+Signed-off-by: Yann E. MORIN <yann.morin.1998@free.fr>
+---
+ package/dhcpcd/S41dhcpcd      | 2 +-
+ package/dhcpcd/dhcpcd.service | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/package/dhcpcd/S41dhcpcd b/package/dhcpcd/S41dhcpcd
+index 3e5c22f715..55794f4075 100644
+--- a/package/dhcpcd/S41dhcpcd
++++ b/package/dhcpcd/S41dhcpcd
+@@ -5,7 +5,7 @@
+ 
+ DAEMON=/sbin/dhcpcd
+ CONFIG=/etc/dhcpcd.conf
+-PIDFILE=/var/run/dhcpcd.pid
++PIDFILE=/var/run/dhcpcd/pid
+ 
+ [ -f $CONFIG ] || exit 0
+ 
+diff --git a/package/dhcpcd/dhcpcd.service b/package/dhcpcd/dhcpcd.service
+index e648092c9b..4da49818a7 100644
+--- a/package/dhcpcd/dhcpcd.service
++++ b/package/dhcpcd/dhcpcd.service
+@@ -5,7 +5,7 @@ After=network.target
+ [Service]
+ Type=forking
+ EnvironmentFile=-/etc/default/dhcpcd
+-PIDFile=/run/dhcpcd.pid
++PIDFile=/run/dhcpcd/pid
+ ExecStart=/sbin/dhcpcd $DAEMON_ARGS
+ Restart=always
+ 
+-- 
+2.34.1
+

--- a/patches-buildroot/series
+++ b/patches-buildroot/series
@@ -1,0 +1,1 @@
+package-dhcpcd-fix-pid-path.patch


### PR DESCRIPTION
* Fix stopping of dhcpcd service.

  Attempt to stop dhcpcd would fail.

  Upstream buildroot had fixed this.  Pull the fix into patches-buildroot
  and add it to series so it is applied.

  Fixes #107

* Update patches-buildroot/README

  this README file stated that nothing would apply these patches,
  when bin/bundle *will* apply patches according to a series file.

