### PR TITLE
Fix "none" datasource to create output directory.

### DIFF
--- a/src/lib/cirros/ds/none
+++ b/src/lib/cirros/ds/none
@@ -20,6 +20,8 @@ EOF
 search_local() {
 	local out_d="$1"
 	local data_d="${out_d}/data"
+	[ -d "$out_d" ] || mkdir -p "$out_d" ||
+		{ error "failed to create output dir"; return 1; }
 	echo "i-dsnone" > "${data_d}/instance-id"
 	echo 0 > "$out_d/result"
 }


### PR DESCRIPTION
When src/sbin/cirros-ds calls a datasource it passes a directory that does not yet exist.  The datasource (/lib/cirros/ds/nocloud) is expected to create it.

The none datasource was not doing that. As a result, you'd see:

   /lib/cirros/ds/none:
      line 23: can't create .../none/data/instance-id: nonexistent
      line 24: can't create .../none/result: nonexistent directory