### PR TITLE
Fixed the readlink in init script

### DIFF
--- a/src/etc/init.d/S50dropbear
+++ b/src/etc/init.d/S50dropbear
@@ -17,7 +17,7 @@ start() {
 
 	# Handle symlinked directories
 	if [ -L "$dropbear_key_dir" ]; then
-		dropbear_key_dir=$(readlink -f "$dropbear_key_dir")
+		dropbear_key_dir=$(readlink "$dropbear_key_dir")
 	fi
 
 	# Ensure host keys are changed when instance ID changes


### PR DESCRIPTION
Init script 'S50-dropbear' updated 'dropbear_key_dir' variable to read the target location of the symlink using 'readlink'. 
But the result was not the target of the link. Now fixed it with removing the switch '-f' for 'readlink'

Because of this issue, host keys are not generated and as a result unable to SSH in to cirros VMs

This is what seen with cirros 0.5.2
$ readlink -f /etc/dropbear
/etc/dropbear
$ readlink  /etc/dropbear
/var/run/dropbear