### PR TITLE
Add vmware specific modules

### DIFF
--- a/src/etc/modules
+++ b/src/etc/modules
@@ -16,6 +16,11 @@ virtio_scsi
 virtio-gpu
 virtio-rng
 
+## Vmware
+vmw_pvscsi
+vmxnet3
+mptspi
+
 ## Input devices
 usbhid
 hid-generic


### PR DESCRIPTION
- vmw_pvscsi is the paravirtual scsi driver
- vmxnet3 the paravirtual network driver
- mptspi is the lsilogic scsi driver commonly used