### PR TITLE
Add virtiofs module

### DIFF
--- a/src/etc/modules
+++ b/src/etc/modules
@@ -15,6 +15,7 @@ virtio_pci
 virtio_scsi
 virtio-gpu
 virtio-rng
+virtiofs
 
 ## Input devices
 usbhid


### PR DESCRIPTION
This module allows to mount host filesystems on the guest with good performances.
https://virtio-fs.gitlab.io/

Nova should introduce a feature to use virtiofs with manila shares.
Adding this module will allow us to test this feature with tempest tests.