### PR TITLE
[dhcpcd] Drop fallback to ipv4ll and increase wait time to 180s

### DIFF
--- a/src/etc/init.d/S40network
+++ b/src/etc/init.d/S40network
@@ -7,7 +7,7 @@ case "$1" in
   start)
 	printf "Starting network: "
 	/sbin/ifup lo
-	/sbin/dhcpcd
+	/sbin/dhcpcd --noipv4ll -w -t 180
 	[ $? = 0 ] && echo "OK" || echo "FAIL"
 	;;
   stop)


### PR DESCRIPTION
With the switch to dhcpcd in [1] we are hitting random
issues in our jobs where dhcp server takes some time to
be ready while cirros just use ipv4ll address and don't
retry. With udhcpc it was not the case, also it used
to retry 3 times every 60 seconds before giving up.

Currently it immediately forks to background as it
detects interface do not have carrier acquired, and
continues other operations like metadata fetch to configure
ssh keys but since dhcp ip and routes not configured
for metadata, metadata fetch also fails.

Added -w option with timeout of 180s similar to udhcpc, this
will make it to wait for ip for 180s before forking to background
and continuing with other operations like metadata fetch.

[1] https://github.com/cirros-dev/cirros/commit/ded54d
Related-Bug: https://bugs.launchpad.net/neutron/+bug/2045549