### PR TITLE
Fix handling of /etc/dropbear

### DIFF
--- a/src/etc/init.d/S50dropbear
+++ b/src/etc/init.d/S50dropbear
@@ -15,9 +15,15 @@ start() {
 	umask 077
 	local dropbear_key_dir="/etc/dropbear"
 
-	# Handle symlinked directories
-	if [ -L "$dropbear_key_dir" ]; then
-		dropbear_key_dir=$(readlink -f "$dropbear_key_dir")
+	# If /etc/dropbear is not a directory, and
+	#   - the filesystem is RO (i.e. we can not rm the symlink),
+	#     create the directory pointed to by the symlink.
+	#   - the filesystem is RW (i.e. we can rm the symlink),
+	#     replace the symlink with an actual directory
+	if ! [ -d /etc/dropbear ]; then
+		if ! rm -f /etc/dropbear; then
+			dropbear_key_dir=$(readlink "$dropbear_key_dir")
+		fi
 	fi
 
 	# Ensure host keys are changed when instance ID changes
@@ -26,7 +32,7 @@ start() {
 
 	# Regenerate invalid or missing keys
 	local ktype file
-	for ktype in rsa ecdsa; do
+	for ktype in rsa ecdsa ed25519; do
 		file="${dropbear_key_dir}/dropbear_${ktype}_host_key"
 		# -f = input file, -y = validate and print pubkey info
 		if ! dropbearkey -f "$file" -y &>/dev/null; then


### PR DESCRIPTION
buildroot starts out with /etc/dropbear being a symlink to /var/run/dropbear in order to allow dropbear to start even when /etc is located on a RO filesystem. The startup script is then to check whether the symlink can be replaced by an actual directory, which then allows to permanently store the hostkeys that dropbear generates, ensuring the keys will persist across reboots. This patch amends the S50dropbear init script to copy this functionality from the original buildroot script.

Also add ed25519 to the list of hostkey types that are generated before dropbear starts.

Fixes: #118